### PR TITLE
Issue #89: Rename DemoProjectFactory to ProjectFactory

### DIFF
--- a/pub/index-lizards-and-pumpkins.php
+++ b/pub/index-lizards-and-pumpkins.php
@@ -3,12 +3,12 @@
 namespace LizardsAndPumpkins;
 
 use LizardsAndPumpkins\Http\HttpRequest;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once '../vendor/autoload.php';
 
 $request = HttpRequest::fromGlobalState(file_get_contents('php://input'));
-$implementationSpecificFactory = new DemoProjectFactory();
+$implementationSpecificFactory = new ProjectFactory();
 
 $website = new DefaultWebFront($request, $implementationSpecificFactory);
 $website->run();

--- a/src/lizards-and-pumpkins/bin/clearFileStorages.php
+++ b/src/lizards-and-pumpkins/bin/clearFileStorages.php
@@ -10,7 +10,7 @@ use LizardsAndPumpkins\Util\BaseCliCommand;
 use LizardsAndPumpkins\Util\Factory\CommonFactory;
 use LizardsAndPumpkins\Util\Factory\MasterFactory;
 use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
@@ -31,7 +31,7 @@ class ClearFileStorage extends BaseCliCommand
     {
         $factory = new SampleMasterFactory();
         $factory->register(new CommonFactory());
-        $factory->register(new DemoProjectFactory());
+        $factory->register(new ProjectFactory());
         
         return new self($factory, new CLImate());
     }

--- a/src/lizards-and-pumpkins/bin/commandConsumer.php
+++ b/src/lizards-and-pumpkins/bin/commandConsumer.php
@@ -9,7 +9,7 @@ use LizardsAndPumpkins\Logging\LoggingCommandHandlerFactory;
 use LizardsAndPumpkins\Logging\LoggingQueueFactory;
 use LizardsAndPumpkins\Util\Factory\CommonFactory;
 use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
@@ -24,13 +24,13 @@ class CommandConsumerWorker
     {
         $this->factory = new SampleMasterFactory();
         $commonFactory = new CommonFactory();
-        $implementationFactory = new DemoProjectFactory();
+        $implementationFactory = new ProjectFactory();
         $this->factory->register($commonFactory);
         $this->factory->register($implementationFactory);
         //$this->enableDebugLogging($commonFactory, $implementationFactory);
     }
 
-    private function enableDebugLogging(CommonFactory $commonFactory, DemoProjectFactory $implementationFactory)
+    private function enableDebugLogging(CommonFactory $commonFactory, ProjectFactory $implementationFactory)
     {
         $this->factory->register(new LoggingCommandHandlerFactory($commonFactory));
         $this->factory->register(new LoggingQueueFactory($implementationFactory));

--- a/src/lizards-and-pumpkins/bin/eventConsumer.php
+++ b/src/lizards-and-pumpkins/bin/eventConsumer.php
@@ -12,7 +12,7 @@ use LizardsAndPumpkins\ProductDetail\Import\UpdatingProductImportCommandFactory;
 use LizardsAndPumpkins\ProductListing\Import\UpdatingProductListingImportCommandFactory;
 use LizardsAndPumpkins\Util\Factory\CommonFactory;
 use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
@@ -27,7 +27,7 @@ class EventConsumerWorker
     {
         $this->factory = new SampleMasterFactory();
         $commonFactory = new CommonFactory();
-        $implementationFactory = new DemoProjectFactory();
+        $implementationFactory = new ProjectFactory();
         $this->factory->register($commonFactory);
         $this->factory->register($implementationFactory);
         $this->factory->register(new UpdatingProductImportCommandFactory());
@@ -36,7 +36,7 @@ class EventConsumerWorker
         //$this->enableDebugLogging($commonFactory, $implementationFactory);
     }
 
-    private function enableDebugLogging(CommonFactory $commonFactory, DemoProjectFactory $implementationFactory)
+    private function enableDebugLogging(CommonFactory $commonFactory, ProjectFactory $implementationFactory)
     {
         $this->factory->register(new LoggingDomainEventHandlerFactory($commonFactory));
         $this->factory->register(new LoggingQueueFactory($implementationFactory));

--- a/src/lizards-and-pumpkins/bin/listUrlKeys.php
+++ b/src/lizards-and-pumpkins/bin/listUrlKeys.php
@@ -11,7 +11,7 @@ use LizardsAndPumpkins\Util\BaseCliCommand;
 use LizardsAndPumpkins\Util\Factory\CommonFactory;
 use LizardsAndPumpkins\Util\Factory\MasterFactory;
 use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
@@ -36,7 +36,7 @@ class ListUrlKeys extends BaseCliCommand
     {
         $factory = new SampleMasterFactory();
         $factory->register(new CommonFactory());
-        $factory->register(new DemoProjectFactory());
+        $factory->register(new ProjectFactory());
 
         return new self($factory, new CLImate());
     }

--- a/src/lizards-and-pumpkins/bin/reportQueueCount.php
+++ b/src/lizards-and-pumpkins/bin/reportQueueCount.php
@@ -11,7 +11,7 @@ use LizardsAndPumpkins\Util\BaseCliCommand;
 use LizardsAndPumpkins\Util\Factory\CommonFactory;
 use LizardsAndPumpkins\Util\Factory\MasterFactory;
 use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
@@ -32,7 +32,7 @@ class ReportQueueCount extends BaseCliCommand
     {
         $factory = new SampleMasterFactory();
         $factory->register(new CommonFactory());
-        $factory->register(new DemoProjectFactory());
+        $factory->register(new ProjectFactory());
 
         return new self($factory, new CLImate());
     }

--- a/src/lizards-and-pumpkins/bin/runContentBlockImport.php
+++ b/src/lizards-and-pumpkins/bin/runContentBlockImport.php
@@ -16,7 +16,7 @@ use LizardsAndPumpkins\Util\BaseCliCommand;
 use LizardsAndPumpkins\Util\Factory\CommonFactory;
 use LizardsAndPumpkins\Util\Factory\MasterFactory;
 use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
@@ -37,7 +37,7 @@ class RunContentBlockImport extends BaseCliCommand
     {
         $factory = new SampleMasterFactory();
         $commonFactory = new CommonFactory();
-        $implementationFactory = new DemoProjectFactory();
+        $implementationFactory = new ProjectFactory();
         $factory->register($commonFactory);
         $factory->register($implementationFactory);
         //self::enableDebugLogging($factory, $implementationFactory, $commonFactory);
@@ -47,7 +47,7 @@ class RunContentBlockImport extends BaseCliCommand
 
     private static function enableDebugLogging(
         MasterFactory $factory,
-        DemoProjectFactory $implementationFactory,
+        ProjectFactory $implementationFactory,
         CommonFactory $commonFactory
     ) {
         $factory->register(new LoggingDomainEventHandlerFactory($commonFactory));

--- a/src/lizards-and-pumpkins/bin/runImport.php
+++ b/src/lizards-and-pumpkins/bin/runImport.php
@@ -19,7 +19,7 @@ use LizardsAndPumpkins\Util\BaseCliCommand;
 use LizardsAndPumpkins\Util\Factory\CommonFactory;
 use LizardsAndPumpkins\Util\Factory\MasterFactory;
 use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
@@ -40,7 +40,7 @@ class RunImport extends BaseCliCommand
     {
         $factory = new SampleMasterFactory();
         $commonFactory = new CommonFactory();
-        $implementationFactory = new DemoProjectFactory();
+        $implementationFactory = new ProjectFactory();
         $factory->register($commonFactory);
         $factory->register($implementationFactory);
         $factory->register(new UpdatingProductImportCommandFactory());
@@ -53,7 +53,7 @@ class RunImport extends BaseCliCommand
     private static function enableDebugLogging(
         MasterFactory $factory,
         CommonFactory $commonFactory,
-        DemoProjectFactory $implementationFactory
+        ProjectFactory $implementationFactory
     ) {
         $factory->register(new LoggingDomainEventHandlerFactory($commonFactory));
         $factory->register(new LoggingCommandHandlerFactory($commonFactory));

--- a/src/lizards-and-pumpkins/bin/shutdownConsumerProcess.php
+++ b/src/lizards-and-pumpkins/bin/shutdownConsumerProcess.php
@@ -11,7 +11,7 @@ use LizardsAndPumpkins\Util\BaseCliCommand;
 use LizardsAndPumpkins\Util\Factory\CommonFactory;
 use LizardsAndPumpkins\Util\Factory\MasterFactory;
 use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
@@ -32,7 +32,7 @@ class ShutdownConsumer extends BaseCliCommand
     {
         $factory = new SampleMasterFactory();
         $factory->register(new CommonFactory());
-        $factory->register(new DemoProjectFactory());
+        $factory->register(new ProjectFactory());
 
         return new self($factory, new CLImate());
     }

--- a/src/lizards-and-pumpkins/bin/triggerTemplateUpdate.php
+++ b/src/lizards-and-pumpkins/bin/triggerTemplateUpdate.php
@@ -16,7 +16,7 @@ use LizardsAndPumpkins\Util\BaseCliCommand;
 use LizardsAndPumpkins\Util\Factory\CommonFactory;
 use LizardsAndPumpkins\Util\Factory\MasterFactory;
 use LizardsAndPumpkins\Util\Factory\SampleMasterFactory;
-use LizardsAndPumpkins\Util\Factory\DemoProjectFactory;
+use LizardsAndPumpkins\Util\Factory\ProjectFactory;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
@@ -37,7 +37,7 @@ class TriggerTemplateUpdate extends BaseCliCommand
     {
         $factory = new SampleMasterFactory();
         $commonFactory = new CommonFactory();
-        $implementationFactory = new DemoProjectFactory();
+        $implementationFactory = new ProjectFactory();
         $factory->register($commonFactory);
         $factory->register($implementationFactory);
 
@@ -49,7 +49,7 @@ class TriggerTemplateUpdate extends BaseCliCommand
     private static function enableDebugLogging(
         MasterFactory $factory,
         CommonFactory $commonFactory,
-        DemoProjectFactory $implementationFactory
+        ProjectFactory $implementationFactory
     ) {
         $factory->register(new LoggingDomainEventHandlerFactory($commonFactory));
         $factory->register(new LoggingCommandHandlerFactory($commonFactory));

--- a/src/lizards-and-pumpkins/src/Util/Factory/ProjectFactory.php
+++ b/src/lizards-and-pumpkins/src/Util/Factory/ProjectFactory.php
@@ -73,7 +73,7 @@ use LizardsAndPumpkins\Util\FileSystem\LocalFilesystemStorageReader;
 use LizardsAndPumpkins\Util\FileSystem\LocalFilesystemStorageWriter;
 use SebastianBergmann\Money\Currency;
 
-class DemoProjectFactory implements Factory, MessageQueueFactory, FactoryWithCallback
+class ProjectFactory implements Factory, MessageQueueFactory, FactoryWithCallback
 {
     use FactoryTrait;
 

--- a/tests/Unit/Suites/Util/Factory/ProjectFactoryTest.php
+++ b/tests/Unit/Suites/Util/Factory/ProjectFactoryTest.php
@@ -34,7 +34,7 @@ use LizardsAndPumpkins\Util\FileSystem\LocalFilesystemStorageWriter;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \LizardsAndPumpkins\Util\Factory\DemoProjectFactory
+ * @covers \LizardsAndPumpkins\Util\Factory\ProjectFactory
  * @uses   \LizardsAndPumpkins\Context\Country\DemoProjectCountryContextPartBuilder
  * @uses   \LizardsAndPumpkins\Context\Locale\DemoProjectLocaleContextPartBuilder
  * @uses   \LizardsAndPumpkins\Context\Website\DemoProjectWebsiteContextPartBuilder
@@ -44,10 +44,10 @@ use PHPUnit\Framework\TestCase;
  * @uses   \LizardsAndPumpkins\Import\Tax\DemoProjectTaxableCountries
  * @uses   \LizardsAndPumpkins\ProductListing\Import\DemoProjectProductListingTitleSnippetRenderer
  */
-class DemoProjectFactoryTest extends TestCase
+class ProjectFactoryTest extends TestCase
 {
     /**
-     * @var DemoProjectFactory
+     * @var ProjectFactory
      */
     private $factory;
 
@@ -87,7 +87,7 @@ class DemoProjectFactoryTest extends TestCase
         $masterFactory = new SampleMasterFactory();
         $masterFactory->register(new CommonFactory());
         $masterFactory->register(new UnitTestFactory($this));
-        $this->factory = new DemoProjectFactory();
+        $this->factory = new ProjectFactory();
         $masterFactory->register($this->factory);
     }
 


### PR DESCRIPTION
Rename DemoProjectFactory to ProjectFactory so it can be bootstrapped automatically by catalog console commands.

Closes #89 