### PR TITLE
Issue #108: use getAssetsBaseUrl() instead of getBaseUrl() where appropriate

### DIFF
--- a/src/lizards-and-pumpkins/src/Util/Factory/ProjectFactory.php
+++ b/src/lizards-and-pumpkins/src/Util/Factory/ProjectFactory.php
@@ -66,7 +66,6 @@ use LizardsAndPumpkins\ProductDetail\Import\View\DemoProjectProductPageTitle;
 use LizardsAndPumpkins\ProductListing\ContentDelivery\ProductsPerPage;
 use LizardsAndPumpkins\ProductListing\Import\DemoProjectProductListingTitleSnippetRenderer;
 use LizardsAndPumpkins\ProductSearch\ContentDelivery\SearchFieldToRequestParamMap;
-use LizardsAndPumpkins\RestApi\RestApiFactory;
 use LizardsAndPumpkins\Util\Config\ConfigReader;
 use LizardsAndPumpkins\Util\FileSystem\LocalFilesystemStorageReader;
 use LizardsAndPumpkins\Util\FileSystem\LocalFilesystemStorageWriter;

--- a/src/lizards-and-pumpkins/theme/template/footer.phtml
+++ b/src/lizards-and-pumpkins/theme/template/footer.phtml
@@ -19,7 +19,7 @@ declare(strict_types=1);
     <div class="footer-trust clearfix">
         <div class="col span_6">
             <p class="trust-title"><?= $this->__('Secure payment<br>with SSL encryption') ?></p>
-            <p><img src="<?= $this->getBaseUrl() ?>images/payment-icons.jpg" alt="" class="payment-icons" /></p>
+            <p><img src="<?= $this->getAssetsBaseUrl() ?>images/payment-icons.jpg" alt="" class="payment-icons" /></p>
         </div>
         <div class="col span_6">
             <p class="trust-title"><?= $this->__('Do your have questions?<br>Please contat us!') ?></p>
@@ -56,21 +56,21 @@ declare(strict_types=1);
             <p class="link">
                 <a href="https://www.facebook.com" title="LP @ Facebook" target="_blank">
                     <svg class="icon facebook" viewBox="0 0 1024 1024">
-                        <use xlink:href="<?= $this->getBaseUrl() ?>images/assets.svg#facebook"></use>
+                        <use xlink:href="<?= $this->getAssetsBaseUrl() ?>images/assets.svg#facebook"></use>
                     </svg>
                 </a>
             </p>
             <p class="link">
                 <a href="https://twitter.com" title="LP @ Twitter" target="_blank">
                     <svg class="icon twitter" viewBox="0 0 1024 1024">
-                        <use xlink:href="<?= $this->getBaseUrl() ?>images/assets.svg#twitter"></use>
+                        <use xlink:href="<?= $this->getAssetsBaseUrl() ?>images/assets.svg#twitter"></use>
                     </svg>
                 </a>
             </p>
             <p class="link">
                 <a href="https://www.youtube.com" title="LP @ Youtube" target="_blank">
                     <svg class="icon youtube" viewBox="0 0 1024 1024">
-                        <use xlink:href="<?= $this->getBaseUrl() ?>images/assets.svg#youtube"></use>
+                        <use xlink:href="<?= $this->getAssetsBaseUrl() ?>images/assets.svg#youtube"></use>
                     </svg>
                 </a>
             </p>

--- a/src/lizards-and-pumpkins/theme/template/head.phtml
+++ b/src/lizards-and-pumpkins/theme/template/head.phtml
@@ -9,9 +9,9 @@ declare(strict_types=1);
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title><?= $this->getChildOutput('title') ?></title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
-<link rel="icon" href="<?= $this->getBaseUrl() ?>images/favicon.ico" type="image/x-icon" />
+<link rel="icon" href="<?= $this->getAssetsBaseUrl() ?>images/favicon.ico" type="image/x-icon" />
 
-<link type="text/css" rel="stylesheet" href="<?= $this->getBaseUrl() ?>css/<?= $this->getLayoutHandle() ?>.css" />
+<link type="text/css" rel="stylesheet" href="<?= $this->getAssetsBaseUrl() ?>css/<?= $this->getLayoutHandle() ?>.css" />
 
-<script data-main="<?= $this->getBaseUrl() ?>js/<?= $this->getLayoutHandle() ?>" src="<?= $this->getBaseUrl() ?>js/lib/require.js"></script>
+<script data-main="<?= $this->getAssetsBaseUrl() ?>js/<?= $this->getLayoutHandle() ?>" src="<?= $this->getAssetsBaseUrl() ?>js/lib/require.js"></script>
 {{snippet head_container}}

--- a/src/lizards-and-pumpkins/theme/template/header.phtml
+++ b/src/lizards-and-pumpkins/theme/template/header.phtml
@@ -15,15 +15,15 @@ $currentWebsiteCode = $this->getWebsiteCode();
             <p><?= $this->__('Please, chose your language') ?></p>
 
             <a class="lang-flag" href="<?= preg_replace('#[^/]+/?$#', 'de/', $this->getBaseUrl()) ?>">
-                <img src="<?= $this->getBaseUrl() ?>images/flags/de.png" alt=""/>
+                <img src="<?= $this->getAssetsBaseUrl() ?>images/flags/de.png" alt=""/>
                 <span>Deutsch</span>
             </a>
             <a class="lang-flag" href="<?= preg_replace('#[^/]+/?$#', 'en/', $this->getBaseUrl()) ?>">
-                <img src="<?= $this->getBaseUrl() ?>images/flags/en.png" alt=""/>
+                <img src="<?= $this->getAssetsBaseUrl() ?>images/flags/en.png" alt=""/>
                 <span>English</span>
             </a>
             <a class="lang-flag" href="<?= preg_replace('#[^/]+/?$#', 'fr/', $this->getBaseUrl()) ?>">
-                <img src="<?= $this->getBaseUrl() ?>images/flags/fr.png" alt=""/>
+                <img src="<?= $this->getAssetsBaseUrl() ?>images/flags/fr.png" alt=""/>
                 <span>Français</span>
             </a>
 
@@ -41,28 +41,28 @@ $currentWebsiteCode = $this->getWebsiteCode();
            title="<?= $this->__(' - Lizards & Pumpkins') ?>"
            class="logo" >
             <svg class="icon main-logo" viewBox="0 0 1024 1024">
-                <use xlink:href="<?= $this->getBaseUrl() ?>images/assets.svg#main-logo"></use>
+                <use xlink:href="<?= $this->getAssetsBaseUrl() ?>images/assets.svg#main-logo"></use>
             </svg>
             <svg class="icon mobile-logo" viewBox="0 0 1024 1024">
-                <use xlink:href="<?= $this->getBaseUrl() ?>images/assets.svg#mobile-logo"></use>
+                <use xlink:href="<?= $this->getAssetsBaseUrl() ?>images/assets.svg#mobile-logo"></use>
             </svg>
         </a>
 
         <i id="mobile-search">
             <svg class="icon magnifier" viewBox="0 0 1024 1024">
-                <use xlink:href="<?= $this->getBaseUrl() ?>images/assets.svg#magnifier"></use>
+                <use xlink:href="<?= $this->getAssetsBaseUrl() ?>images/assets.svg#magnifier"></use>
             </svg>
         </i>
 
         <ul class="top-links">
             <li id="account-meta"></li>
             <li id="language-switcher">
-                <img src="<?= $this->getBaseUrl() ?>images/flags/<?= $currentWebsiteCode ?>.png" alt=""/>
+                <img src="<?= $this->getAssetsBaseUrl() ?>images/flags/<?= $currentWebsiteCode ?>.png" alt=""/>
             </li>
             <li>
                 <a href="<?= $this->getBaseUrl() ?>checkout/cart/">
                     <svg class="icon-shopping-bag" viewBox="0 0 1024 1024">
-                        <use xlink:href="<?= $this->getBaseUrl() ?>images/assets.svg#shopping-bag"></use>
+                        <use xlink:href="<?= $this->getAssetsBaseUrl() ?>images/assets.svg#shopping-bag"></use>
                     </svg>
                     <span id="cart-meta-info"></span>
                 </a>
@@ -78,7 +78,7 @@ $currentWebsiteCode = $this->getWebsiteCode();
 
                     <button type="submit" title="<?= $this->__('Search') ?>">
                         <svg class="icon magnifier" viewBox="0 0 1024 1024">
-                            <use xlink:href="<?= $this->getBaseUrl() ?>images/assets.svg#magnifier"></use>
+                            <use xlink:href="<?= $this->getAssetsBaseUrl() ?>images/assets.svg#magnifier"></use>
                         </svg>
                     </button>
 

--- a/src/lizards-and-pumpkins/theme/template/list.phtml
+++ b/src/lizards-and-pumpkins/theme/template/list.phtml
@@ -15,5 +15,6 @@ declare(strict_types=1);
         selectedSortOrder = {{snippet selected_sort_order}},
         translations = {{snippet translations}},
         baseUrl = '<?= $this->getBaseUrl() ?>',
+        assetsBaseUrl = '<?= $this->getAssetsBaseUrl() ?>',
         basePricePattern = '<?= sprintf($this->__('per %s%s %s &euro;'), '%s', '%s', '%s') ?>';
 </script>

--- a/src/lizards-and-pumpkins/theme/template/product-details.phtml
+++ b/src/lizards-and-pumpkins/theme/template/product-details.phtml
@@ -13,6 +13,7 @@ use LizardsAndPumpkins\ProductDetail\Import\ConfigurableProductJsonSnippetRender
 
     var stockQty = '<?= $this->getProductStockQuantity() ?>',
         baseUrl = '<?= $this->getBaseUrl() ?>',
+        assetsBaseUrl = '<?= $this->getAssetsBaseUrl() ?>',
         product = <?= $this->getChildOutput('product_json') ?>,
         variation_attributes = <?= $this->getChildOutput(ConfigurableProductJson::VARIATION_ATTRIBUTES_CODE) ?>,
         associated_products = <?= $this->getChildOutput(ConfigurableProductJson::ASSOCIATED_PRODUCTS_CODE) ?>,


### PR DESCRIPTION
Use `getAssetsBaseUrl()` instead of `getBaseUrl()` where appropriate.

Closes #108